### PR TITLE
generate truly unique sensor names

### DIFF
--- a/custom_components/vigicrues/sensor.py
+++ b/custom_components/vigicrues/sensor.py
@@ -131,7 +131,8 @@ class Vigicrues(object):
         return self.__get_last_point("Q")
 
     def get_name(self):
-        return self.get_data("H").get("Serie").get("LbStationHydro")
+        serie_data = self.get_data("H").get("Serie")
+        return f"{serie_data.get('LbStationHydro')} - {serie_data.get('CdStationHydro')}"
 
     def get_data(self, _type):
         params = {"CdStationHydro": self.station_id, "GrdSerie": _type}


### PR DESCRIPTION
Some stations have the same ` LbStationHydro`  label, which means that the generated sensor name is not unique for HomeAssistant:
````
2024-08-13 16:52:16.767 ERROR (MainThread) [homeassistant.components.sensor] Platform vigicrues does not generate unique IDs
````

An example:
* https://www.vigicrues.gouv.fr/services/observations.json/index.php?CdStationHydro=V123561001
* https://www.vigicrues.gouv.fr/services/observations.json/index.php?CdStationHydro=V123521001

I'm aware this will rename/create new sensors for the existing installations, I'll let you judge if this is acceptable for you or not.